### PR TITLE
Fix issue with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -10,6 +10,5 @@ let package = Package(
     targets: [
         .target(name: "UInt128"),
         .testTarget(name: "UInt128Tests", dependencies: ["UInt128"]),
-    ],
-    swiftLanguageVersions: [.v5]
+    ]
 )


### PR DESCRIPTION
It fixes an issue where SPM was complaining about tools version incompatibility.

`Dependencies could not be resolved because 'uint128' >= 0.5.0 contains incompatible tools version (3.1.0) and root depends on 'uint128' 0.8.0..<1.0.0.`