### PR TITLE
Updated _valueToString again.

### DIFF
--- a/Sources/UInt128/UInt128.swift
+++ b/Sources/UInt128/UInt128.swift
@@ -594,7 +594,7 @@ extension UInt128 : CustomStringConvertible {
     /// Converts the stored value into a string representation based on radix.
     /// - Parameters:
     ///   - radix: The radix for the base numbering system to emit. Default is 10.
-    ///   - uppercase: Specify true for uppercase and false for lowercase  for returned String.
+    ///   - uppercase: Specify true for uppercase and false for lowercase for returned String.
     /// - Returns: String representation of the stored UInt128 value.
     /// - Precondition: Valid radix is from 2...36
     /// - Complexity: O(n) where n is the number of decimal digits in the final representation

--- a/Tests/UInt128Tests/UInt128PerformanceTests.swift
+++ b/Tests/UInt128Tests/UInt128PerformanceTests.swift
@@ -1,0 +1,57 @@
+//
+//  UInt128PerformanceTests.swift
+//  UInt128Tests
+//
+//  Created by Craig A. Munro on 5/17/23.
+//
+
+import XCTest
+
+@testable import UInt128
+
+final class UInt128PerformanceTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testPerformance_valueToString() throws {
+        
+        let value = UInt128.max
+
+        let options = XCTMeasureOptions()
+        options.iterationCount = 1000
+        
+        self.measure(options: options) {
+            _ = value._valueToString()
+        }
+    }
+    
+//    func testPerformance_valueToStringPrevious() throws {
+//        
+//        let value = UInt128.max
+//
+//        let options = XCTMeasureOptions()
+//        options.iterationCount = 1000
+//        
+//        self.measure(options: options) {
+//            _ = value._valueToStringPrevious()
+//        }
+//    }
+    
+    func testPerformance_valueFromString() throws {
+        
+        let options = XCTMeasureOptions()
+        options.iterationCount = 1000
+        
+        self.measure(options: options) {
+            _ = UInt128._valueFromString("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")!
+        }
+    }
+}
+
+


### PR DESCRIPTION
Updated func documentation.
Added reserveCapacity() customized for each supported well known radix.

Changed result.insert() since it is an O(n) complexity each time through repeat loop, where n is the length of the string. To append and then return reversed once when done. result.append(characterPool[index])
...
return String(result.reversed()) is an O(1) complexity

Added UInt128PerformanceTests to verify improvement. All tests passed.